### PR TITLE
aws > terraform > made rds + elasticache configurable

### DIFF
--- a/.env-aws
+++ b/.env-aws
@@ -15,4 +15,7 @@ POSTGRES_ROOT_PASSWORD=
 ## Optional values
 ## ---------------
 
+RDS_INSTANCE_CLASS=
+ELASTICACHE_NODE_TYPE=
+
 SSL_DOMAIN=

--- a/aws/elasticache.tf
+++ b/aws/elasticache.tf
@@ -6,11 +6,13 @@ resource "aws_elasticache_subnet_group" "main" {
 resource "aws_elasticache_cluster" "redis" {
   cluster_id                    = "${var.environment}-${var.app_name}-redis"
   engine                        = "redis"
-  node_type                     = "cache.r4.xlarge"
+  node_type                     = var.elasticache_node_type
   num_cache_nodes               = 1
   parameter_group_name          = "default.redis5.0"
   engine_version                = "5.0.6"
   port                          = 6379
+
+  apply_immediately             = true
  
   snapshot_retention_limit      = 5
   snapshot_window               = "00:00-05:00"

--- a/aws/rds.tf
+++ b/aws/rds.tf
@@ -19,7 +19,7 @@ resource "aws_db_instance" "postgres" {
 
   engine                                    = "postgres"
   engine_version                            = "11.5"
-  instance_class                            = "db.t3.small"
+  instance_class                            = var.rds_instance_class
   parameter_group_name                      = aws_db_parameter_group.postgres.name
   storage_type                              = "gp2"
   replicate_source_db                       = null

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -66,6 +66,14 @@ variable "ssl_domain" {
   default     = ""
 }
 
+variable "elasticache_node_type" {
+  description = "The ElastiCache node type used for Redis."
+}
+
+variable "rds_instance_class" {
+  description = "The RDS instance class type used for Postgres."
+}
+
 variable "microservices" {
   description   = "A key / value mapping of microservices to ports."
   default       = {

--- a/scripts/terraform-aws.sh
+++ b/scripts/terraform-aws.sh
@@ -46,12 +46,15 @@ else
   AWS_ACCESS_KEY_ID=$(grep AWS_ACCESS_KEY_ID $CACHE_DIR/.env-aws | cut -d '=' -f2)
   AWS_SECRET_ACCESS_KEY=$(grep AWS_SECRET_ACCESS_KEY $CACHE_DIR/.env-aws | cut -d '=' -f2)
   AWS_REGION=$(grep AWS_REGION $CACHE_DIR/.env-aws | cut -d '=' -f2)
+  ELASTICACHE_NODE_TYPE=$(grep ELASTICACHE_NODE_TYPE $CACHE_DIR/.env-aws | cut -d '=' -f2)
+  RDS_INSTANCE_CLASS=$(grep RDS_INSTANCE_CLASS $CACHE_DIR/.env-aws | cut -d '=' -f2)
   POSTGRES_ROOT_USERNAME=$(grep POSTGRES_ROOT_USERNAME $CACHE_DIR/.env-aws | cut -d '=' -f2)
   POSTGRES_ROOT_PASSWORD=$(grep POSTGRES_ROOT_PASSWORD $CACHE_DIR/.env-aws | cut -d '=' -f2)
   SSL_DOMAIN=$(grep SSL_DOMAIN $CACHE_DIR/.env-aws | cut -d '=' -f2)
   PUBLIC_KEY=$(cat $SECURE_DIR/id_rsa.pub)
   PRIVATE_KEY=$(cat $SECURE_DIR/id_rsa)
 
+  # required variables
   if [ "$TF_BUCKET" == "" ]; then
     echo "TF_BUCKET is empty. Please add it to your \".env-aws\" file"
     exit 1
@@ -77,6 +80,15 @@ else
     echo "⚠️  SSL_DOMAIN is empty. Please add it to your \".env-aws\" file to add SSL support."
   fi
 
+  # optional variables
+  if [ "$ELASTICACHE_NODE_TYPE" == "" ]; then
+    RDS_INSTANCE_CLASS = "cache.r4.xlarge"
+  fi
+
+  if [ "$RDS_INSTANCE_CLASS" == "" ]; then
+    RDS_INSTANCE_CLASS = "db.t3.small"
+  fi
+
   # Create or copy terraform variables file (vars.auto.tfvars)
   TF_VARS_FILE=$TF_DIR/vars.auto.tfvars
   if [ -f "$ROOT_DIR/aws/vars.auto.tfvars" ]; then
@@ -89,6 +101,8 @@ else
   echo "aws_access_key_id=\"$AWS_ACCESS_KEY_ID\"" >> $TF_VARS_FILE
   echo "aws_secret_access_key=\"$AWS_SECRET_ACCESS_KEY\"" >> $TF_VARS_FILE
   echo "aws_region=\"$AWS_REGION\"" >> $TF_VARS_FILE
+  echo "elasticache_node_type=\"$ELASTICACHE_NODE_TYPE\"" >> $TF_VARS_FILE
+  echo "rds_instance_class=\"$RDS_INSTANCE_CLASS\"" >> $TF_VARS_FILE
   echo "postgres_root_username=\"$POSTGRES_ROOT_USERNAME\"" >> $TF_VARS_FILE
   echo "postgres_root_password=\"$POSTGRES_ROOT_PASSWORD\"" >> $TF_VARS_FILE
   echo "ssl_domain=\"$SSL_DOMAIN\"" >> $TF_VARS_FILE


### PR DESCRIPTION
**Overview**
This PR allows the ElastiCache and RDS instances in the AWS terraform configuration to be configurable via environment variables set in `.env-aws`. Additionally, it makes changes to ElastiCache applied immediately, _which may lead to brief downtime_.