### PR TITLE
Reduce EC2 Instances

### DIFF
--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -91,13 +91,11 @@ locals {
   ec2s = {
     web         = [
       "cerberus",
+      "hercules",
       "hermes",
       "passport",
       "rest-api",
       "web-app",
-    ],
-    worker      = [
-      "hercules"
     ]
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - ./volume:/var/paragon
     restart: unless-stopped
     cpus: "${DOCKER_WEB_CPU:-0.3}"
-    mem_limit: ${DOCKER_WEB_MEMORY:-2460}M
+    mem_limit: ${DOCKER_WEB_MEMORY:-1230}M
 
   hercules:
     container_name: paragon-hercules
@@ -48,7 +48,7 @@ services:
       - ./volume:/var/paragon
     restart: unless-stopped
     cpus: "${DOCKER_WEB_CPU:-0.3}"
-    mem_limit: ${DOCKER_WEB_MEMORY:-2460}M
+    mem_limit: ${DOCKER_WEB_MEMORY:-1230}M
 
   rest-api:
     container_name: paragon-api
@@ -63,7 +63,7 @@ services:
       - ./volume:/var/paragon
     restart: unless-stopped
     cpus: "${DOCKER_WEB_CPU:-0.3}"
-    mem_limit: ${DOCKER_WEB_MEMORY:-2460}M
+    mem_limit: ${DOCKER_WEB_MEMORY:-1230}M
 
   web-app:
     container_name: paragon-web
@@ -78,7 +78,7 @@ services:
       - ./volume:/var/paragon
     restart: unless-stopped
     cpus: "${DOCKER_WEB_CPU:-0.3}"
-    mem_limit: ${DOCKER_WEB_MEMORY:-2460}M
+    mem_limit: ${DOCKER_WEB_MEMORY:-1230}M
 
   passport:
     container_name: paragon-passport
@@ -93,4 +93,4 @@ services:
       - ./volume:/var/paragon
     restart: unless-stopped
     cpus: "${DOCKER_WEB_CPU:-0.3}"
-    mem_limit: ${DOCKER_WEB_MEMORY:-2460}M
+    mem_limit: ${DOCKER_WEB_MEMORY:-1230}M

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
     volumes:
       - ./volume:/var/paragon
     restart: unless-stopped
-    cpus: "${DOCKER_WEB_CPU:-0.7}"
-    mem_limit: ${DOCKER_WEB_MEMORY:-2560}M
+    cpus: "${DOCKER_WEB_CPU:-0.3}"
+    mem_limit: ${DOCKER_WEB_MEMORY:-2460}M
 
   hercules:
     container_name: paragon-hercules
@@ -32,8 +32,8 @@ services:
     volumes:
       - ./volume:/var/paragon
     restart: unless-stopped
-    cpus: "${DOCKER_WORKER_CPU:-3.0}"
-    mem_limit: ${DOCKER_WORKER_MEMORY:-12288}M
+    cpus: "${DOCKER_WORKER_CPU:-1.75}"
+    mem_limit: ${DOCKER_WORKER_MEMORY:-6144}M
 
   hermes:
     container_name: paragon-hermes
@@ -47,8 +47,8 @@ services:
     volumes:
       - ./volume:/var/paragon
     restart: unless-stopped
-    cpus: "${DOCKER_WEB_CPU:-0.7}"
-    mem_limit: ${DOCKER_WEB_MEMORY:-2560}M
+    cpus: "${DOCKER_WEB_CPU:-0.3}"
+    mem_limit: ${DOCKER_WEB_MEMORY:-2460}M
 
   rest-api:
     container_name: paragon-api
@@ -62,8 +62,8 @@ services:
     volumes:
       - ./volume:/var/paragon
     restart: unless-stopped
-    cpus: "${DOCKER_WEB_CPU:-0.7}"
-    mem_limit: ${DOCKER_WEB_MEMORY:-2560}M
+    cpus: "${DOCKER_WEB_CPU:-0.3}"
+    mem_limit: ${DOCKER_WEB_MEMORY:-2460}M
 
   web-app:
     container_name: paragon-web
@@ -77,8 +77,8 @@ services:
     volumes:
       - ./volume:/var/paragon
     restart: unless-stopped
-    cpus: "${DOCKER_WEB_CPU:-0.7}"
-    mem_limit: ${DOCKER_WEB_MEMORY:-2560}M
+    cpus: "${DOCKER_WEB_CPU:-0.3}"
+    mem_limit: ${DOCKER_WEB_MEMORY:-2460}M
 
   passport:
     container_name: paragon-passport
@@ -92,5 +92,5 @@ services:
     volumes:
       - ./volume:/var/paragon
     restart: unless-stopped
-    cpus: "${DOCKER_WEB_CPU:-0.7}"
-    mem_limit: ${DOCKER_WEB_MEMORY:-2560}M
+    cpus: "${DOCKER_WEB_CPU:-0.3}"
+    mem_limit: ${DOCKER_WEB_MEMORY:-2460}M


### PR DESCRIPTION
**Overview**
This PR reduces the EC2s needed to run the installation from 2 down to 1. Additionally it lowers the default allocated memory and cpu for each microservice.